### PR TITLE
Add `ProvisioningStyle: Automatic;` to framework target

### DIFF
--- a/Diff.xcodeproj/project.pbxproj
+++ b/Diff.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 					};
 					C9EE87151CCFCA83006BD90E = {
 						CreatedOnToolsVersion = 7.3;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};


### PR DESCRIPTION
Provisioning style 'Automatic' is the most consumer friendly provisioning style for frameworks. It permits the host project to dictate the provisioning style.
Otherwise if a host project specifies Manual provisioning style, xcodebuild will fail when attempting to compile the subproject with:

> Diff does not support provisioning profiles. Diff does not support provisioning profiles, but provisioning profile <my provisioning profile> has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.