### PR TITLE
Makes codecov only report coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: true
+comment:
+  behavior: default
+  layout: header, diff
+  require_changes: false
+coverage:
+  precision: 2
+  range:
+  - 70.0
+  - 100.0
+  round: down
+  status:
+    changes: false
+    patch: false
+    project: false
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      macro: false
+      method: false
+  javascript:
+    enable_partials: false


### PR DESCRIPTION
codecov failed builds when the code coverage was lower than previously. This is a bit frustrating because it doesn't always make sense to increase test coverage.