### PR TITLE
Fix wrong .gitignore for Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,9 @@ DerivedData
 *.ipa
 *.xcuserstate
 
-Carthage/Checkouts
-Carthage/Build
+**/Carthage/Checkouts
+**/Carthage/Build
 PerfTests/Benchmark/Cartfile.resolved
-PerfTests/Benchmark/Carthage/Checkouts/
 
 #SPM
 .build/

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ DerivedData
 *.ipa
 *.xcuserstate
 
-*/Carthage/Checkouts/
-*/Carthage/Build/
+Carthage/Checkouts
+Carthage/Build
 PerfTests/Benchmark/Cartfile.resolved
 PerfTests/Benchmark/Carthage/Checkouts/
 


### PR DESCRIPTION
`*/Carthage/Build/` pattern is not working.
Carthage/Build is correct pattern.

I confirmed that in https://github.com/ReactiveKit/Bond

