### PR TITLE
Not ignore Cartfile.resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ DerivedData
 
 */Carthage/Checkouts/
 */Carthage/Build/
-PerfTests/Benchmark/Cartfile.resolved
 PerfTests/Benchmark/Carthage/Checkouts/
 
 #SPM

--- a/PerfTests/Benchmark/Cartfile.resolved
+++ b/PerfTests/Benchmark/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "jflinter/Dwifft" "0.5"


### PR DESCRIPTION
`Cartfile.resolved` should be committed to get exactly same dependencies during build.

Check out official doc about that,
https://github.com/Carthage/Carthage/blob/83bbffd25172df767cf578ca17b0cfbbbf913d35/Documentation/Artifacts.md#cartfileresolved
