### PR TITLE
Add Transform to IndexPath's when working with UI

### DIFF
--- a/Diff.xcodeproj/project.pbxproj
+++ b/Diff.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C9D4BC961E1124CE00C79537 /* NestedExtendedDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D4BC951E1124CE00C79537 /* NestedExtendedDiff.swift */; };
 		C9EE87841CCFFB68006BD90E /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EE87821CCFFB68006BD90E /* Diff.swift */; };
 		C9EE87861CCFFB68006BD90E /* Patch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EE87831CCFFB68006BD90E /* Patch.swift */; };
+		E2F1C8561E3A14DF00FBE786 /* BatchUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F1C8551E3A14DF00FBE786 /* BatchUpdateTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 		C9EE87161CCFCA83006BD90E /* Diff.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Diff.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9EE87821CCFFB68006BD90E /* Diff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Diff.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C9EE87831CCFFB68006BD90E /* Patch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Patch.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		E2F1C8551E3A14DF00FBE786 /* BatchUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BatchUpdateTests.swift; path = DiffTests/BatchUpdateTests.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 				C90CD7181DFB43C600BE9114 /* NestedDiffTests.swift */,
 				C921BF701E15448300747566 /* NestedExtendedDiffTests.swift */,
 				C9838FF51D29571000691BE8 /* Info.plist */,
+				E2F1C8551E3A14DF00FBE786 /* BatchUpdateTests.swift */,
 			);
 			path = DiffTests;
 			sourceTree = "<group>";
@@ -245,6 +248,7 @@
 				C99118AC1DDDAD6E00067A60 /* ExtendedPatchSortTests.swift in Sources */,
 				C921BF711E15448300747566 /* NestedExtendedDiffTests.swift in Sources */,
 				C90CD7191DFB43C600BE9114 /* NestedDiffTests.swift in Sources */,
+				E2F1C8561E3A14DF00FBE786 /* BatchUpdateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diff.xcodeproj/xcshareddata/xcbaselines/C9838FF01D29571000691BE8.xcbaseline/5ACB3D1B-D608-4861-BD7C-4E5E202E879C.plist
+++ b/Diff.xcodeproj/xcshareddata/xcbaselines/C9838FF01D29571000691BE8.xcbaseline/5ACB3D1B-D608-4861-BD7C-4E5E202E879C.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>BatchUpdateTests</key>
+		<dict>
+			<key>testCellsPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.14952</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Diff.xcodeproj/xcshareddata/xcbaselines/C9838FF01D29571000691BE8.xcbaseline/Info.plist
+++ b/Diff.xcodeproj/xcshareddata/xcbaselines/C9838FF01D29571000691BE8.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>5ACB3D1B-D608-4861-BD7C-4E5E202E879C</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i5</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2900</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro12,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>i386</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone5,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/DiffTests/BatchUpdateTests.swift
+++ b/DiffTests/BatchUpdateTests.swift
@@ -48,19 +48,19 @@ class BatchUpdateTests: XCTestCase {
             XCTAssertEqual(batch.moves, expectation.2.2.map { (transform($0.0), transform($0.1)) })
         }
     }
-
-    // MARK: Performance Tests
-    func testCellsPerformance() {
-        self.measure {
-            self._testCells()
-        }
-    }
-
-    func testCellsWithTransformPerformance() {
-        self.measure {
-            self._testCellsWithTransform()
-        }
-    }
+//
+//    // MARK: Performance Tests
+//    func testCellsPerformance() {
+//        self.measure {
+//            self._testCells()
+//        }
+//    }
+//
+//    func testCellsWithTransformPerformance() {
+//        self.measure {
+//            self._testCellsWithTransform()
+//        }
+//    }
 }
 
 // #endif

--- a/DiffTests/BatchUpdateTests.swift
+++ b/DiffTests/BatchUpdateTests.swift
@@ -1,0 +1,66 @@
+// #if !os(macOS) && !os(watchOS)
+
+import XCTest
+@testable import Diff
+
+func IP(_ row: Int, _ section: Int) -> IndexPath {
+    return IndexPath(row: row, section: section)
+}
+
+class BatchUpdateTests: XCTestCase {
+
+    let cellExpectations = [
+        ([1, 2, 3, 4], [1, 2, 3, 4], ([], [], [])),
+        ([1, 2, 3, 4], [4, 2, 3, 1], ([], [], [(IP(0, 0), IP(3, 0)), (IP(3, 0), IP(0, 0))])),
+        ([1, 2, 3, 4], [2, 3, 1], ([IP(3, 0)], [], [(IP(0, 0), IP(2, 0))])),
+        ([1, 2, 3, 4], [5, 2, 3, 4], ([IP(0, 0)], [IP(0, 0)], [])),
+        ([1, 2, 3, 4], [4, 1, 3, 5], ([IP(1, 0)], [IP(3, 0)], [(IP(2, 0), IP(0, 0))])),
+        ([1, 2, 3, 4], [4, 2, 3, 4], ([IP(0, 0)], [IP(0, 0)], [])),
+        ([1, 2, 3, 4], [1, 2, 4, 4], ([IP(2, 0)], [IP(3, 0)], [])),
+        ([1, 2, 3, 4], [5, 6, 7, 8], ([IP(0, 0), IP(1, 0), IP(2, 0), IP(3, 0)], [IP(0, 0), IP(1, 0), IP(2, 0), IP(3, 0)], [])),
+        ([1, 2, 3, 4], [5, 6, 7, 1], ([IP(1, 0), IP(2, 0), IP(3, 0)], [IP(0, 0), IP(1, 0), IP(2, 0)], [])),
+    ]
+
+    func testCells() {
+        _testCells()
+    }
+
+    func testCellsWithTransform() {
+        _testCellsWithTransform()
+    }
+
+    func _testCells() {
+        for expectation in cellExpectations {
+            let batch = BatchUpdate(diff: expectation.0.extendedDiff(expectation.1))
+            XCTAssertEqual(batch.deletions, expectation.2.0)
+            XCTAssertEqual(batch.insertions, expectation.2.1)
+            XCTAssertEqual(batch.moves, expectation.2.2)
+        }
+    }
+
+    func _testCellsWithTransform() {
+        let transform: (IndexPath) -> IndexPath = { IP($0.row + 1, $0.section + 2) }
+
+        for expectation in cellExpectations {
+            let batch = BatchUpdate(diff: expectation.0.extendedDiff(expectation.1), indexPathTransform: transform)
+            XCTAssertEqual(batch.deletions, expectation.2.0.map(transform))
+            XCTAssertEqual(batch.insertions, expectation.2.1.map(transform))
+            XCTAssertEqual(batch.moves, expectation.2.2.map { (transform($0.0), transform($0.1)) })
+        }
+    }
+
+    // MARK: Performance Tests
+    func testCellsPerformance() {
+        self.measure {
+            self._testCells()
+        }
+    }
+
+    func testCellsWithTransformPerformance() {
+        self.measure {
+            self._testCellsWithTransform()
+        }
+    }
+}
+
+// #endif

--- a/DiffTests/BatchUpdateTests.swift
+++ b/DiffTests/BatchUpdateTests.swift
@@ -1,4 +1,4 @@
-// #if !os(macOS) && !os(watchOS)
+#if !os(macOS) && !os(watchOS)
 
 import XCTest
 @testable import Diff
@@ -48,19 +48,20 @@ class BatchUpdateTests: XCTestCase {
             XCTAssertEqual(batch.moves, expectation.2.2.map { (transform($0.0), transform($0.1)) })
         }
     }
-//
-//    // MARK: Performance Tests
-//    func testCellsPerformance() {
-//        self.measure {
-//            self._testCells()
-//        }
-//    }
-//
-//    func testCellsWithTransformPerformance() {
-//        self.measure {
-//            self._testCellsWithTransform()
-//        }
-//    }
+
+    //
+    //    // MARK: Performance Tests
+    //    func testCellsPerformance() {
+    //        self.measure {
+    //            self._testCells()
+    //        }
+    //    }
+    //
+    //    func testCellsWithTransformPerformance() {
+    //        self.measure {
+    //            self._testCellsWithTransform()
+    //        }
+    //    }
 }
 
-// #endif
+#endif

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -125,11 +125,11 @@ public extension UITableView {
         )
     }
     
-    private func apply(
+    public func apply(
         _ diff: ExtendedDiff,
         deletionAnimation: UITableViewRowAnimation = .automatic,
         insertionAnimation: UITableViewRowAnimation = .automatic,
-        indexPathTransform: (IndexPath) -> IndexPath
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 }
         ) {
 		let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
 
@@ -316,7 +316,7 @@ public extension UICollectionView {
     public func apply(
         _ diff: ExtendedDiff,
         completion: ((Bool) -> Swift.Void)? = nil,
-        indexPathTransform: @escaping (IndexPath) -> IndexPath
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
         ) {
         performBatchUpdates({
             let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -301,7 +301,6 @@ public extension UITableView {
         ) {
         
         let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
-		
         beginUpdates()
         deleteRows(at: update.itemDeletions, with: rowDeletionAnimation)
         insertRows(at: update.itemInsertions, with: rowInsertionAnimation)

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -131,7 +131,7 @@ public extension UITableView {
         insertionAnimation: UITableViewRowAnimation = .automatic,
         indexPathTransform: (IndexPath) -> IndexPath = { $0 }
         ) {
-		let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
+        let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
 
         beginUpdates()
         deleteRows(at: update.deletions, with: deletionAnimation)

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -86,11 +86,11 @@ public extension UITableView {
 
     /// Animates rows which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UITableView`
+    /// - parameter newData:            Data which reflects the current state of `UITableView`
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
-    /// - parameter indexPathTransform: Closure which transforms
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     public func animateRowChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -108,11 +108,12 @@ public extension UITableView {
     
     /// Animates rows which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UITableView`
+    /// - parameter newData:            Data which reflects the current state of `UITableView`
     /// - parameter isEqual:            A function comparing two elements of `T`
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     public func animateRowChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -147,10 +148,12 @@ public extension UITableView {
     
     /// Animates rows and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UITableView`
+    /// - parameter newData:            Data which reflects the current state of `UITableView`
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateRowAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -178,10 +181,12 @@ public extension UITableView {
     
     /// Animates rows and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UITableView`
+    /// - parameter newData:            Data which reflects the current state of `UITableView`
     /// - parameter isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)    /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateRowAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -212,10 +217,12 @@ public extension UITableView {
     
     /// Animates rows and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UITableView`
+    /// - parameter newData:            Data which reflects the current state of `UITableView`
     /// - parameter isEqualSection:     A function comparing two sections (elements of `T`)
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateRowAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -246,12 +253,14 @@ public extension UITableView {
     
     /// Animates rows and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableVie
+    /// - parameter oldData:            Data which reflects the previous state of `UITableView`
+    /// - parameter newData:            Data which reflects the current state of `UITableView`
     /// - parameter isEqualSection:     A function comparing two sections (elements of `T`)
     /// - parameter isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateRowAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -308,8 +317,9 @@ public extension UICollectionView {
 
     /// Animates items which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UICollectionView`
+    /// - parameter newData:            Data which reflects the current state of `UICollectionView`
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     public func animateItemChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -322,9 +332,10 @@ public extension UICollectionView {
     
     /// Animates items which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UICollectionView`
+    /// - parameter newData:            Data which reflects the current state of `UICollectionView`
     /// - parameter isEqual:            A function comparing two elements of `T`
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
     public func animateItemChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -351,10 +362,12 @@ public extension UICollectionView {
     
     /// Animates items and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UICollectionView`
+    /// - parameter newData:            Data which reflects the current state of `UICollectionView`
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -375,11 +388,13 @@ public extension UICollectionView {
     
     /// Animates items and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UICollectionView`
+    /// - parameter newData:            Data which reflects the current state of `UICollectionView`
     /// - parameter isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -403,11 +418,13 @@ public extension UICollectionView {
     
     /// Animates items and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UICollectionView`
+    /// - parameter newData:            Data which reflects the current state of `UICollectionView`
     /// - parameter isEqualSection:     A function comparing two sections (elements of `T`)
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -431,12 +448,14 @@ public extension UICollectionView {
     
     /// Animates items and sections which changed between oldData and newData.
     ///
-    /// - parameter oldData:            Data which reflects the previous state of UITableView
-    /// - parameter newData:            Data which reflects the current state of UITableView
+    /// - parameter oldData:            Data which reflects the previous state of `UICollectionView`
+    /// - parameter newData:            Data which reflects the current state of `UICollectionView`
     /// - parameter isEqualSection:     A function comparing two sections (elements of `T`)
     /// - parameter isEqualElement:     A function comparing two items (elements of `T.Iterator.Element`)
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms zero-based `IndexPath` to desired  `IndexPath`
+    /// - parameter sectionTransform:   Closure which transforms zero-based section(`Int`) into desired section(`Int`)
     public func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -43,7 +43,11 @@ struct NestedBatchUpdate {
     let sectionInsertions: IndexSet
     let sectionMoves: [(from: Int, to: Int)]
     
-    init(diff: NestedExtendedDiff) {
+    init(
+        diff: NestedExtendedDiff,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: (Int) -> Int = { $0 }
+        ) {
         
         var itemDeletions: [IndexPath] = []
         var itemInsertions: [IndexPath] = []
@@ -55,17 +59,17 @@ struct NestedBatchUpdate {
         diff.forEach { element in
             switch element {
             case let .deleteElement(at, section):
-                itemDeletions.append(IndexPath(item: at, section: section))
+                itemDeletions.append(indexPathTransform(IndexPath(item: at, section: section)))
             case let .insertElement(at, section):
-                itemInsertions.append(IndexPath(item: at, section: section))
+                itemInsertions.append(indexPathTransform(IndexPath(item: at, section: section)))
             case let .moveElement(from, to):
-                itemMoves.append((IndexPath(item: from.item, section: from.section), IndexPath(item: to.item, section: to.section)))
+                itemMoves.append((indexPathTransform(IndexPath(item: from.item, section: from.section)), indexPathTransform(IndexPath(item: to.item, section: to.section))))
             case let .deleteSection(at):
-                sectionDeletions.insert(at)
+                sectionDeletions.insert(sectionTransform(at))
             case let .insertSection(at):
-                sectionInsertions.insert(at)
+                sectionInsertions.insert(sectionTransform(at))
             case let .moveSection(move):
-                sectionMoves.append(move)
+                sectionMoves.append((sectionTransform(move.from), sectionTransform(move.to)))
             }
         }
         
@@ -86,6 +90,7 @@ public extension UITableView {
     /// - parameter newData:            Data which reflects the current state of UITableView
     /// - parameter deletionAnimation:  Animation type for deletions
     /// - parameter insertionAnimation: Animation type for insertions
+    /// - parameter indexPathTransform: Closure which transforms
     public func animateRowChanges<T: Collection>(
         oldData: T,
         newData: T,
@@ -152,7 +157,9 @@ public extension UITableView {
         rowDeletionAnimation: UITableViewRowAnimation = .automatic,
         rowInsertionAnimation: UITableViewRowAnimation = .automatic,
         sectionDeletionAnimation: UITableViewRowAnimation = .automatic,
-        sectionInsertionAnimation: UITableViewRowAnimation = .automatic
+        sectionInsertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: (Int) -> Int = { $0 }
         )
         where T.Iterator.Element: Collection,
         T.Iterator.Element: Equatable,
@@ -162,7 +169,9 @@ public extension UITableView {
                 rowDeletionAnimation: rowDeletionAnimation,
                 rowInsertionAnimation: rowInsertionAnimation,
                 sectionDeletionAnimation: sectionDeletionAnimation,
-                sectionInsertionAnimation: sectionInsertionAnimation
+                sectionInsertionAnimation: sectionInsertionAnimation,
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform
             )
     }
     
@@ -181,7 +190,9 @@ public extension UITableView {
         rowDeletionAnimation: UITableViewRowAnimation = .automatic,
         rowInsertionAnimation: UITableViewRowAnimation = .automatic,
         sectionDeletionAnimation: UITableViewRowAnimation = .automatic,
-        sectionInsertionAnimation: UITableViewRowAnimation = .automatic
+        sectionInsertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: (Int) -> Int = { $0 }
         )
         where T.Iterator.Element: Collection,
         T.Iterator.Element: Equatable {
@@ -193,7 +204,9 @@ public extension UITableView {
                 rowDeletionAnimation: rowDeletionAnimation,
                 rowInsertionAnimation: rowInsertionAnimation,
                 sectionDeletionAnimation: sectionDeletionAnimation,
-                sectionInsertionAnimation: sectionInsertionAnimation
+                sectionInsertionAnimation: sectionInsertionAnimation,
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform
             )
     }
     
@@ -211,7 +224,9 @@ public extension UITableView {
         rowDeletionAnimation: UITableViewRowAnimation = .automatic,
         rowInsertionAnimation: UITableViewRowAnimation = .automatic,
         sectionDeletionAnimation: UITableViewRowAnimation = .automatic,
-        sectionInsertionAnimation: UITableViewRowAnimation = .automatic
+        sectionInsertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: (Int) -> Int = { $0 }
         )
         where T.Iterator.Element: Collection,
         T.Iterator.Element.Iterator.Element: Equatable {
@@ -223,7 +238,9 @@ public extension UITableView {
                 rowDeletionAnimation: rowDeletionAnimation,
                 rowInsertionAnimation: rowInsertionAnimation,
                 sectionDeletionAnimation: sectionDeletionAnimation,
-                sectionInsertionAnimation: sectionInsertionAnimation
+                sectionInsertionAnimation: sectionInsertionAnimation,
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform
             )
     }
     
@@ -244,7 +261,9 @@ public extension UITableView {
         rowDeletionAnimation: UITableViewRowAnimation = .automatic,
         rowInsertionAnimation: UITableViewRowAnimation = .automatic,
         sectionDeletionAnimation: UITableViewRowAnimation = .automatic,
-        sectionInsertionAnimation: UITableViewRowAnimation = .automatic
+        sectionInsertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: (Int) -> Int = { $0 }
         )
         where T.Iterator.Element: Collection {
             apply(
@@ -256,7 +275,9 @@ public extension UITableView {
                 rowDeletionAnimation: rowDeletionAnimation,
                 rowInsertionAnimation: rowInsertionAnimation,
                 sectionDeletionAnimation: sectionDeletionAnimation,
-                sectionInsertionAnimation: sectionInsertionAnimation
+                sectionInsertionAnimation: sectionInsertionAnimation,
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform
             )
     }
     
@@ -265,11 +286,13 @@ public extension UITableView {
         rowDeletionAnimation: UITableViewRowAnimation = .automatic,
         rowInsertionAnimation: UITableViewRowAnimation = .automatic,
         sectionDeletionAnimation: UITableViewRowAnimation = .automatic,
-        sectionInsertionAnimation: UITableViewRowAnimation = .automatic
+        sectionInsertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath,
+        sectionTransform: (Int) -> Int
         ) {
         
-        let update = NestedBatchUpdate(diff: diff)
-        
+        let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
+		
         beginUpdates()
         deleteRows(at: update.itemDeletions, with: rowDeletionAnimation)
         insertRows(at: update.itemInsertions, with: rowInsertionAnimation)
@@ -290,8 +313,8 @@ public extension UICollectionView {
     public func animateItemChanges<T: Collection>(
         oldData: T,
         newData: T,
-        completion: ((Bool) -> Void)? = nil,
-        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        completion: ((Bool) -> Void)? = nil
     ) where T.Iterator.Element: Equatable {
         let diff = oldData.extendedDiff(newData)
         apply(diff, completion: completion, indexPathTransform: indexPathTransform)
@@ -306,8 +329,8 @@ public extension UICollectionView {
         oldData: T,
         newData: T,
         isEqual: EqualityChecker<T>,
-        completion: ((Bool) -> Swift.Void)? = nil,
-        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        completion: ((Bool) -> Swift.Void)? = nil
         ) {
         let diff = oldData.extendedDiff(newData, isEqual: isEqual)
         apply(diff, completion: completion, indexPathTransform: indexPathTransform)
@@ -335,6 +358,8 @@ public extension UICollectionView {
     public func animateItemAndSectionChanges<T: Collection>(
         oldData: T,
         newData: T,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
         where T.Iterator.Element: Collection,
@@ -342,6 +367,8 @@ public extension UICollectionView {
         T.Iterator.Element.Iterator.Element: Equatable {
             apply(
                 oldData.nestedExtendedDiff(to: newData),
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform,
                 completion: completion
             )
     }
@@ -357,6 +384,8 @@ public extension UICollectionView {
         oldData: T,
         newData: T,
         isEqualElement: NestedElementEqualityChecker<T>,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
         where T.Iterator.Element: Collection,
@@ -366,6 +395,8 @@ public extension UICollectionView {
                     to: newData,
                     isEqualElement: isEqualElement
                 ),
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform,
                 completion: completion
             )
     }
@@ -381,6 +412,8 @@ public extension UICollectionView {
         oldData: T,
         newData: T,
         isEqualSection: EqualityChecker<T>,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
         where T.Iterator.Element: Collection,
@@ -390,6 +423,8 @@ public extension UICollectionView {
                     to: newData,
                     isEqualSection: isEqualSection
                 ),
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform,
                 completion: completion
         )
     }
@@ -407,6 +442,8 @@ public extension UICollectionView {
         newData: T,
         isEqualSection: EqualityChecker<T>,
         isEqualElement: NestedElementEqualityChecker<T>,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Swift.Void)? = nil
         )
         where T.Iterator.Element: Collection {
@@ -416,16 +453,20 @@ public extension UICollectionView {
                     isEqualSection: isEqualSection,
                     isEqualElement: isEqualElement
                 ),
+                indexPathTransform: indexPathTransform,
+                sectionTransform: sectionTransform,
                 completion: completion
         )
     }
     
     public func apply(
         _ diff: NestedExtendedDiff,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 },
+        sectionTransform: @escaping (Int) -> Int = { $0 },
         completion: ((Bool) -> Void)? = nil
         ) {
         performBatchUpdates({ 
-            let update = NestedBatchUpdate(diff: diff)
+            let update = NestedBatchUpdate(diff: diff, indexPathTransform: indexPathTransform, sectionTransform: sectionTransform)
             self.insertSections(update.sectionInsertions)
             self.deleteSections(update.sectionDeletions)
             update.sectionMoves.forEach { self.moveSection($0.from, toSection: $0.to) }

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -7,25 +7,28 @@ struct BatchUpdate {
     let insertions: [IndexPath]
     let moves: [(from: IndexPath, to: IndexPath)]
 
-    init(diff: ExtendedDiff) {
+    init(
+		diff: ExtendedDiff,
+		indexPathTransform: (IndexPath) -> IndexPath = { $0 }
+		) {
         deletions = diff.flatMap { element -> IndexPath? in
             switch element {
             case .delete(let at):
-                return IndexPath(row: at, section: 0)
+                return indexPathTransform(IndexPath(row: at, section: 0))
             default: return nil
             }
         }
         insertions = diff.flatMap { element -> IndexPath? in
             switch element {
             case .insert(let at):
-                return IndexPath(row: at, section: 0)
+                return indexPathTransform(IndexPath(row: at, section: 0))
             default: return nil
             }
         }
         moves = diff.flatMap { element -> (IndexPath, IndexPath)? in
             switch element {
             case let .move(from, to):
-                return (IndexPath(row: from, section: 0), IndexPath(row: to, section: 0))
+                return (indexPathTransform(IndexPath(row: from, section: 0)), indexPathTransform(IndexPath(row: to, section: 0)))
             default: return nil
             }
         }
@@ -87,12 +90,14 @@ public extension UITableView {
         oldData: T,
         newData: T,
         deletionAnimation: UITableViewRowAnimation = .automatic,
-        insertionAnimation: UITableViewRowAnimation = .automatic
+        insertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 }
     ) where T.Iterator.Element: Equatable {
         apply(
             oldData.extendedDiff(newData),
             deletionAnimation: deletionAnimation,
-            insertionAnimation: insertionAnimation
+            insertionAnimation: insertionAnimation,
+            indexPathTransform: indexPathTransform
         )
     }
     
@@ -109,21 +114,24 @@ public extension UITableView {
         // https://twitter.com/dgregor79/status/570068545561735169
         isEqual: (EqualityChecker<T>),
         deletionAnimation: UITableViewRowAnimation = .automatic,
-        insertionAnimation: UITableViewRowAnimation = .automatic
+        insertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 }
         ) {
         apply(
             oldData.extendedDiff(newData, isEqual: isEqual),
             deletionAnimation: deletionAnimation,
-            insertionAnimation: insertionAnimation
+            insertionAnimation: insertionAnimation,
+            indexPathTransform: indexPathTransform
         )
     }
     
     private func apply(
         _ diff: ExtendedDiff,
         deletionAnimation: UITableViewRowAnimation = .automatic,
-        insertionAnimation: UITableViewRowAnimation = .automatic
+        insertionAnimation: UITableViewRowAnimation = .automatic,
+        indexPathTransform: (IndexPath) -> IndexPath
         ) {
-        let update = BatchUpdate(diff: diff)
+		let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
 
         beginUpdates()
         deleteRows(at: update.deletions, with: deletionAnimation)
@@ -282,10 +290,11 @@ public extension UICollectionView {
     public func animateItemChanges<T: Collection>(
         oldData: T,
         newData: T,
-        completion: ((Bool) -> Void)? = nil
+        completion: ((Bool) -> Void)? = nil,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
     ) where T.Iterator.Element: Equatable {
         let diff = oldData.extendedDiff(newData)
-        apply(diff, completion: completion)
+        apply(diff, completion: completion, indexPathTransform: indexPathTransform)
     }
     
     /// Animates items which changed between oldData and newData.
@@ -297,18 +306,20 @@ public extension UICollectionView {
         oldData: T,
         newData: T,
         isEqual: EqualityChecker<T>,
-        completion: ((Bool) -> Swift.Void)? = nil
+        completion: ((Bool) -> Swift.Void)? = nil,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath = { $0 }
         ) {
         let diff = oldData.extendedDiff(newData, isEqual: isEqual)
-        apply(diff, completion: completion)
+        apply(diff, completion: completion, indexPathTransform: indexPathTransform)
     }
     
     public func apply(
         _ diff: ExtendedDiff,
-        completion: ((Bool) -> Swift.Void)? = nil
+        completion: ((Bool) -> Swift.Void)? = nil,
+        indexPathTransform: @escaping (IndexPath) -> IndexPath
         ) {
         performBatchUpdates({
-            let update = BatchUpdate(diff: diff)
+            let update = BatchUpdate(diff: diff, indexPathTransform: indexPathTransform)
             self.deleteItems(at: update.deletions)
             self.insertItems(at: update.insertions)
             update.moves.forEach { self.moveItem(at: $0.from, to: $0.to) }

--- a/Sources/Diff+UIKit.swift
+++ b/Sources/Diff+UIKit.swift
@@ -8,9 +8,9 @@ struct BatchUpdate {
     let moves: [(from: IndexPath, to: IndexPath)]
 
     init(
-		diff: ExtendedDiff,
-		indexPathTransform: (IndexPath) -> IndexPath = { $0 }
-		) {
+        diff: ExtendedDiff,
+        indexPathTransform: (IndexPath) -> IndexPath = { $0 }
+        ) {
         deletions = diff.flatMap { element -> IndexPath? in
             switch element {
             case .delete(let at):


### PR DESCRIPTION
Most of the time due to UI design and ..., developers have extra cells in some sections hence Model is not exactly mapped to the UI presented. This way developers can use these methods if they have extra cells inside the Table/Collection views too.