### PR TITLE
Fix “method should not be declared public because its parameter uses an internal type” warnings

### DIFF
--- a/Sources/NestedExtendedDiff.swift
+++ b/Sources/NestedExtendedDiff.swift
@@ -24,7 +24,7 @@ public struct NestedExtendedDiff: DiffProtocol {
     public let elements: [Element]
 }
 
-typealias NestedElementEqualityChecker<T: Collection> = (T.Iterator.Element.Iterator.Element, T.Iterator.Element.Iterator.Element) -> Bool where T.Iterator.Element: Collection
+public typealias NestedElementEqualityChecker<T: Collection> = (T.Iterator.Element.Iterator.Element, T.Iterator.Element.Iterator.Element) -> Bool where T.Iterator.Element: Collection
 
 public extension Collection
     where Iterator.Element: Collection {


### PR DESCRIPTION
This PR addresses the warning produced under Swift 3.1 betas. It does not address #39, which is to be fixed in Swift itself.