### PR TITLE
Ensure that only API compatible with Application Extensions is used

### DIFF
--- a/Diff.xcodeproj/project.pbxproj
+++ b/Diff.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 			baseConfigurationReference = 900E03AF1DE7F1E80033A799 /* Deployment-Targets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -343,6 +344,7 @@
 			baseConfigurationReference = 900E03AF1DE7F1E80033A799 /* Deployment-Targets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";


### PR DESCRIPTION
I've been seeing warnings when building Bond (which depends on Swift) as it sets `APPLICATION_EXTENSION_API_ONLY = YES`. Given that Diff.swift doesn't use any non-application extension compatible API, it makes sense to do the same here.

Here's the warning this PR resolves:

```
ld: warning: linking against a dylib which is not safe for use in application extensions
```