### PR TITLE
Release version 0.5.3

### DIFF
--- a/Diff.podspec
+++ b/Diff.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Diff"
-  s.version      = "0.5.2"
+  s.version      = "0.5.3"
   s.summary      = "The fastest Diff library in Swift. Includes UICollectionView/UITableView utils."
   s.homepage     = "https://github.com/wokalski/Diff.swift"
   s.description  = <<-DESC
@@ -16,7 +16,7 @@ This library generates differences between any two Collections (and Strings). It
   s.osx.exclude_files = "Sources/Diff+UIKit.swift"
   s.watchos.exclude_files = "Sources/Diff+UIKit.swift"
 
-  s.source       = { :git => "https://github.com/wokalski/Diff.swift.git", :tag => "0.5.2" }
+  s.source       = { :git => "https://github.com/wokalski/Diff.swift.git", :tag => "0.5.3" }
 
   s.source_files  = "Sources"
 end

--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.2</string>
+	<string>0.5.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
There are fixes for Swift 3.1 in `master` (see #45 for details) that it makes sense to release prior to Xcode 8.3's release. This release bundles the following fixes:

- #45 disables duplicate typealiases when compiling for Swift 3.1 and higher. These were required under Swift 3.0.x, but produce compilation errors under Swift 3.1.
- #46 & #48 which improve the `LinkedList` and `DoublyLinkedList` implementations, fixing a recursion crash.